### PR TITLE
CSV mode: Exit after the first stats-epoc

### DIFF
--- a/src/net/capture_engine.cpp
+++ b/src/net/capture_engine.cpp
@@ -15,7 +15,7 @@ CaptureEngine::CaptureEngine(const Config * config, const Pcap * session)
       session(session),
       barrier(new mqueue<Elem>()),
       stats(new Stats(config, barrier)),
-      report(config->getReportType().makeReport(config, session, stats)),
+      report(config->getReportType().makeReport(config, this, stats)),
       _is_terminated(false),
       queue_count(3),
       packets(),
@@ -70,6 +70,7 @@ void CaptureEngine::shutdown()
   _is_terminated = true;
   stats->shutdown();
   report->shutdown();
+  const_cast<Pcap*>(session)->stopCapture();
 }
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/report/csv.cpp
+++ b/src/report/csv.cpp
@@ -5,11 +5,10 @@ namespace mckeys {
 
 using namespace std;
 
-CsvReport::CsvReport(const Config* cfg, const Pcap* session, Stats* stats)
+CsvReport::CsvReport(const Config* cfg, const CaptureEngine* engine, Stats* stats)
   : Report(cfg, Logger::getLogger("csvReport")),
-    stats(stats)
+    engine(engine), stats(stats)
 {
-  (void)session;
   if (state.checkAndSet(state_NEW, state_STARTING)) {
     report_thread = thread(&CsvReport::render, this);
   } else {
@@ -41,6 +40,8 @@ void CsvReport::render()
         printHeader();
       } else {
         cout << ",,,,,," << endl;
+        const_cast<CaptureEngine*>(engine)->shutdown();
+        break;
       }
       renderStats(q);
     }

--- a/src/report/csv.h
+++ b/src/report/csv.h
@@ -2,7 +2,7 @@
 #define _REPORT_CSV_H
 
 #include "config.h"
-#include "net/pcap.h"
+#include "net/capture_engine.h"
 #include "report/report.h"
 #include "util/stats.h"
 
@@ -11,13 +11,14 @@ namespace mckeys {
 class CsvReport : public Report
 {
  public:
-  CsvReport(const Config* cfg, const Pcap* session, Stats* stats);
+  CsvReport(const Config* cfg, const CaptureEngine* engine, Stats* stats);
   virtual void render();
 
  protected:
   void renderStats(std::deque<Stat> q);
 
  private:
+  const CaptureEngine* engine;
   Stats* stats;
 };
 

--- a/src/report/curses.cpp
+++ b/src/report/curses.cpp
@@ -12,9 +12,9 @@ namespace mckeys {
 
 using namespace std;
 
-CursesReport::CursesReport(const Config* cfg, const Pcap* session, Stats* stats)
+CursesReport::CursesReport(const Config* cfg, const CaptureEngine* engine, Stats* stats)
   : Report(cfg, Logger::getLogger("cursesReport")),
-    session(session),
+    engine(engine),
     stats(stats),
     statColumnWidth(10),
     keyColumnWidth(0),
@@ -119,7 +119,7 @@ void CursesReport::renderStats(deque<Stat> q, uint32_t qsize) {
   uint32_t i = 0;
   uint32_t maxlines = LINES - 3 - 1;
 
-  string pstats = session->getStatsString();
+  string pstats = engine->getStatsString();
   ostringstream summary;
   ostringstream fwSummary;
 

--- a/src/report/curses.h
+++ b/src/report/curses.h
@@ -2,7 +2,7 @@
 #define _REPORT_CURSES_H
 
 #include "config.h"
-#include "net/pcap.h"
+#include "net/capture_engine.h"
 #include "report/report.h"
 #include "util/stats.h"
 
@@ -19,7 +19,7 @@ class CursesReport : public Report
   typedef std::vector<std::string> StatColumns;
   typedef std::map<char, std::string> CommandMap;
 
-  CursesReport(const Config* cfg, const Pcap* session, Stats* stats);
+  CursesReport(const Config* cfg, const CaptureEngine* engine, Stats* stats);
   virtual ~CursesReport();
 
   virtual void render();
@@ -38,7 +38,7 @@ class CursesReport : public Report
   void renderInit(); // initialize rendering system - only once before first rendering
   void renderDone(); // tear down render system
   void initFooterText(); // done once by renderInit
-  const Pcap* session;
+  const CaptureEngine* engine;
   Stats* stats;
   int statColumnWidth;
   uint32_t keyColumnWidth;

--- a/src/report/report_type.cpp
+++ b/src/report/report_type.cpp
@@ -40,11 +40,11 @@ bool ReportType::operator==(const ReportType &other) const {
   return (getName() == other.getName());
 }
 
-Report* ReportType::makeReport(const Config* cfg, const Pcap* sess, Stats* stats) {
+Report* ReportType::makeReport(const Config* cfg, const CaptureEngine* engine, Stats* stats) {
   if (cfg->getReportType() == ReportType::NCURSES) {
-    return new CursesReport(cfg, sess, stats);
+    return new CursesReport(cfg, engine, stats);
   } else if (cfg->getReportType() == ReportType::CSV) {
-    return new CsvReport(cfg, sess, stats);
+    return new CsvReport(cfg, engine, stats);
   } else {
     throw range_error("Unsupported report type " + cfg->getReportType().getName());
   }

--- a/src/report/report_type.h
+++ b/src/report/report_type.h
@@ -7,7 +7,7 @@ namespace mckeys {
 
 // forward declarations because shit we have some recursive dependencies
 class Config;
-class Pcap;
+class CaptureEngine;
 class Stats;
 class Report;
 
@@ -19,7 +19,7 @@ class ReportType
 
   static ReportType fromString(const std::string &name);
 
-  Report* makeReport(const Config* cfg, const Pcap* sess, Stats* stats);
+  Report* makeReport(const Config* cfg, const CaptureEngine* engine, Stats* stats);
   std::string getName() const;
 
   bool operator==(const ReportType &other) const;


### PR DESCRIPTION
Before the patch, memkeys in CSV mode(`--report=CSV`) will never exit unless the process is killed.

After the patch, memkeys in CSV mode will just display stats data in first INTERVAL(`--refresh=INTERVAL`) ms and exit (instead of refreshing infinitely). This will make it easier for memkeys to play as a monitor tool.

---

This is a quick but naïve(since `CaptureEngine` is conducted by its inner object -- `Report`) patch, please revert it and reimplement it if anybody has a better idea.

![link](https://cloud.githubusercontent.com/assets/865677/7911277/81e32624-088e-11e5-9168-f534cba7e3d3.gif)
